### PR TITLE
docs: align reviewer model references with config

### DIFF
--- a/.agents/skills/astra-orchestrator/SKILL.md
+++ b/.agents/skills/astra-orchestrator/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: astra-orchestrator
-description: Orchestrate complex Codex coding work with the root agent as planner/integrator and specialized Luna subagents for exploration, implementation, testing, review, and research. Use for multi-file features, debugging across components, repo-wide changes, parallelizable workstreams, or whenever the user asks to delegate or use subagents. Do not use for trivial one-file edits or simple questions.
+description: Orchestrate complex Codex coding work with the root agent as planner/integrator, Luna subagents for exploration, implementation, testing, and research, and an Astra reviewer. Use for multi-file features, debugging across components, repo-wide changes, parallelizable workstreams, or whenever the user asks to delegate or use subagents. Do not use for trivial one-file edits or simple questions.
 ---
 
 # Astra Orchestrator
@@ -17,7 +17,7 @@ The expected default topology is:
 - explorer: GPT-5.6 Luna
 - worker: GPT-5.6 Luna
 - tester: GPT-5.6 Luna
-- reviewer: GPT-5.6 Luna
+- reviewer: GPT-6 Astra
 - researcher: GPT-5.6 Luna
 
 Do not override a Luna subagent to a more expensive model unless the user explicitly asks for that escalation.

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Codex Astra Orchestrator + Luna Subagents
 
-A configurable Codex setup where GPT-6 Astra is the root/orchestrator and GPT-5.6 Luna is the default and pinned model for specialized subagents.
+A configurable Codex setup where GPT-6 Astra is the root/orchestrator and reviewer, while GPT-5.6 Luna is the default and pinned model for execution subagents.
 
 ## Layout
 
@@ -36,14 +36,9 @@ default_subagent_model = "gpt-5.6-luna"
 default_subagent_reasoning_effort = "max"
 ```
 
-Each role file is also explicitly pinned to Luna. This means changing only `default_subagent_model` will affect generic spawned agents, but not the named roles.
+Each role file is explicitly pinned to its intended model: Luna for explorer, worker, tester, and researcher; Astra for reviewer. This means changing only `default_subagent_model` will affect generic spawned agents, but not the named roles.
 
-If you want one knob to control all subagents, remove these two lines from each `.codex/agents/*.toml` file:
-
-```toml
-model = "gpt-5.6-luna"
-model_reasoning_effort = "medium"
-```
+If you want one knob to control all subagents, remove the `model` and `model_reasoning_effort` overrides from each `.codex/agents/*.toml` file.
 
 Then the named roles inherit the `[agents]` defaults.
 
@@ -121,7 +116,7 @@ and reviewer for an independent final review.
             Luna
               |
           reviewer
-            Luna
+           Astra
               |
               v
          GPT-6 Astra
@@ -149,4 +144,4 @@ For strict parent/child separation:
 
 Explicit model choices during a spawn override `[agents]` defaults. Custom agent files that specify `model` or `model_reasoning_effort` also take precedence over inherited defaults.
 
-The included role files are pinned to Luna intentionally, so Astra should remain the orchestrator unless you deliberately change the role configuration.
+The execution role files are pinned to Luna intentionally, while the reviewer is pinned to Astra for independent final review. Astra remains the orchestrator unless you deliberately change the role configuration.

--- a/SKILL.md
+++ b/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: astra-orchestrator
-description: Orchestrate complex Codex coding work with the root agent as planner/integrator and specialized Luna subagents for exploration, implementation, testing, review, and research. Use for multi-file features, debugging across components, repo-wide changes, parallelizable workstreams, or whenever the user asks to delegate or use subagents. Do not use for trivial one-file edits or simple questions.
+description: Orchestrate complex Codex coding work with the root agent as planner/integrator, Luna subagents for exploration, implementation, testing, and research, and an Astra reviewer. Use for multi-file features, debugging across components, repo-wide changes, parallelizable workstreams, or whenever the user asks to delegate or use subagents. Do not use for trivial one-file edits or simple questions.
 ---
 
 # Astra Orchestrator
@@ -17,7 +17,7 @@ The expected default topology is:
 - explorer: GPT-5.6 Luna
 - worker: GPT-5.6 Luna
 - tester: GPT-5.6 Luna
-- reviewer: GPT-5.6 Astra
+- reviewer: GPT-6 Astra
 - researcher: GPT-5.6 Luna
 
 Do not override a Luna subagent to a more expensive model unless the user explicitly asks for that escalation.


### PR DESCRIPTION
## Why

The reviewer role is configured to use GPT-6 Astra, but the README and installed skill still describe it as a Luna subagent. The duplicate root skill also refers to the nonexistent model name `GPT-5.6 Astra`. These mismatches make the documented topology disagree with the configuration users actually install.

## What Changed

- document GPT-6 Astra as the reviewer in the README topology and role descriptions
- update the installed skill to assign the reviewer to GPT-6 Astra
- synchronize the duplicate root skill with the installed skill
- clarify that only the execution roles are pinned to Luna
