### PR TITLE
fix(setup): escape component variable in PowerShell prompt

### DIFF
--- a/setup.ps1
+++ b/setup.ps1
@@ -270,7 +270,7 @@ try {
 
     $installed = 0
     foreach ($component in '.codex', '.agents', 'AGENTS.md') {
-        if (Read-Confirmation -Prompt "Install $component?" -DefaultYes $true) {
+        if (Read-Confirmation -Prompt "Install ${component}?" -DefaultYes $true) {
             if (Install-Component -Name $component -TargetDirectory $targetDirectory) {
                 $installed++
             }


### PR DESCRIPTION
## Summary

Fixes an issue that caused the Windows PowerShell setup script to exit unexpectedly during the interactive project setup process.

## Problem

The script runs with:

```powershell
Set-StrictMode -Version Latest
```

The installation prompt was written as:

```powershell
"Install $component?"
```

PowerShell interprets `$component?` as a variable name instead of treating `?` as a literal question mark. Since `$component?` is not defined, the script fails with:

```text
The variable '$component?' cannot be retrieved because it has not been set
```

## Changes

Explicitly delimit the variable name in the prompt string:

```powershell
"Install ${component}?"
```

This ensures that the question mark is treated as literal text.

## Testing

- Reviewed the PowerShell variable interpolation behavior.
- Verified that the prompt is compatible with `Set-StrictMode -Version Latest`.
- Confirmed that the prompts will display as expected:

```text
Install .codex? [Y/n]
Install .agents? [Y/n]
Install AGENTS.md? [Y/n]
```

## Impact

This is a minimal, low-risk fix limited to the interactive confirmation prompt. It does not change the component installation, overwrite confirmation, or directory merge logic.