### PR TITLE
fix: handle string subagent sources in token usage reports

### DIFF
--- a/scripts/token_usage.py
+++ b/scripts/token_usage.py
@@ -82,6 +82,8 @@ def thread_role(meta: dict) -> tuple[str, str]:
     source = meta.get("source")
     if isinstance(source, dict):
         sub = source.get("subagent") or {}
+        if isinstance(sub, str):
+            return sub, ""
         spawn = sub.get("thread_spawn")
         if isinstance(spawn, dict):
             return spawn.get("agent_role") or "subagent", spawn.get("agent_nickname") or ""

--- a/tests/test_token_usage.py
+++ b/tests/test_token_usage.py
@@ -1,0 +1,104 @@
+import json
+import subprocess
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+
+from scripts.token_usage import thread_role
+
+SCRIPT = Path(__file__).resolve().parents[1] / "scripts" / "token_usage.py"
+STRING_ROLES = ("review", "compact", "memory_consolidation")
+
+
+class ThreadRoleTests(unittest.TestCase):
+    def test_string_subagent_sources(self):
+        for role in STRING_ROLES:
+            with self.subTest(role=role):
+                self.assertEqual(thread_role({"source": {"subagent": role}}), (role, ""))
+
+    def test_existing_source_shapes(self):
+        cases = [
+            ({"id": "root", "session_id": "root", "source": "cli"}, ("root", "")),
+            (
+                {
+                    "source": {
+                        "subagent": {
+                            "thread_spawn": {
+                                "agent_role": "worker",
+                                "agent_nickname": "Luna",
+                            }
+                        }
+                    }
+                },
+                ("worker", "Luna"),
+            ),
+            ({"source": {"subagent": {"other": "guardian"}}}, ("guardian", "")),
+            (
+                {"id": "child", "source": "cli", "thread_source": "guardian_review"},
+                ("guardian_review", ""),
+            ),
+        ]
+        for meta, expected in cases:
+            with self.subTest(meta=meta):
+                self.assertEqual(thread_role(meta), expected)
+
+
+class TokenUsageCliTests(unittest.TestCase):
+    def run_cli(self, *args):
+        with tempfile.TemporaryDirectory() as directory:
+            for index, role in enumerate(("root", *STRING_ROLES)):
+                source = "cli" if role == "root" else {"subagent": role}
+                records = [
+                    {
+                        "type": "session_meta",
+                        "payload": {
+                            "id": role,
+                            "session_id": "root",
+                            "source": source,
+                            "timestamp": "2026-09-09T12:00:00Z",
+                            "cwd": "/example",
+                        },
+                    },
+                    {"type": "turn_context", "payload": {"model": "test-model"}},
+                    {
+                        "type": "token_usage_record",
+                        "payload": {
+                            "usage": {"input_tokens": 90, "output_tokens": 10, "total_tokens": 100},
+                        },
+                    },
+                ]
+                path = Path(directory) / f"rollout-{index}.jsonl"
+                path.write_text(
+                    "\n".join(json.dumps(record) for record in records), encoding="utf-8"
+                )
+            result = subprocess.run(
+                [sys.executable, str(SCRIPT), "--sessions-dir", directory, *args],
+                capture_output=True,
+                text=True,
+                check=False,
+            )
+        self.assertEqual(result.returncode, 0, result.stderr)
+        return result.stdout
+
+    def test_list_counts_string_subagent_sources(self):
+        output = self.run_cli("--list")
+        self.assertRegex(output, r"root\s+3\s+/example")
+
+    def test_latest_renders_string_subagent_roles(self):
+        output = self.run_cli("--latest")
+        self.assertIn("4 (4 counted, 0 auto-review skipped)", output)
+        for role in STRING_ROLES:
+            self.assertIn(f"| {role} | test-model", output)
+
+    def test_root_json_preserves_roles_and_usage(self):
+        report = json.loads(self.run_cli("--root", "root", "--format", "json"))
+        self.assertEqual({thread["role"] for thread in report["threads"]}, {"root", *STRING_ROLES})
+        self.assertEqual(
+            sum(thread["per_model"]["test-model"]["total_tokens"] for thread in report["threads"]),
+            400,
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Codex can serialize `source.subagent` as a string for its `review`, `compact`, and `memory_consolidation` variants. `thread_role()` assumes it is a dictionary and calls `.get("thread_spawn")`, so encountering one of these valid threads crashes token-usage listing and reports:

```python
thread_role({"source": {"subagent": "review"}})
# AttributeError: 'str' object has no attribute 'get'
```

Return the string source as the role before parsing the dictionary variants. Existing root, named-worker, and guardian role handling remains unchanged.

Added standard-library tests for all three string variants and existing role shapes, plus subprocess coverage of `--list`, `--latest`, and `--root --format json` against temporary rollout fixtures. The CLI tests check role labels, subagent counts, and preserved token totals without reading real session logs.

Validation:
- Reproduced the exception before the fix; all three CLI regression tests also failed.
- `python3 -m unittest discover -s tests -v`: all 5 tests pass.
- `python3 -m py_compile scripts/token_usage.py tests/test_token_usage.py` and `git diff --check` pass.
